### PR TITLE
Don't crash the app if multiple instances of the same album is found

### DIFF
--- a/core/database/src/main/java/dk/clausr/core/database/dao/AlbumWithOptionalRatingDao.kt
+++ b/core/database/src/main/java/dk/clausr/core/database/dao/AlbumWithOptionalRatingDao.kt
@@ -84,7 +84,7 @@ interface AlbumWithOptionalRatingDao {
         SELECT *
         FROM albums
         LEFT JOIN ratings ON albums.slug = ratings.albumSlug
-        WHERE LOWER(artist) LIKE LOWER(:artist)   -- Use LIKE for case-insensitive comparison
+        WHERE artist LIKE :artist
         ORDER BY releaseDate DESC
     """,
     )

--- a/feature/overview/src/main/java/dk/clausr/feature/overview/AlbumRow.kt
+++ b/feature/overview/src/main/java/dk/clausr/feature/overview/AlbumRow.kt
@@ -50,7 +50,7 @@ fun AlbumRow(
         ) {
             itemsIndexed(
                 items = albums,
-                key = { i, album -> "${album.album.slug}-$i" },
+                key = { i, album -> "$title-${album.album.slug}-$i" },
             ) { _, album ->
                 val streamingLink = StreamingServices
                     .from(album.album)

--- a/feature/overview/src/main/java/dk/clausr/feature/overview/AlbumRow.kt
+++ b/feature/overview/src/main/java/dk/clausr/feature/overview/AlbumRow.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -48,10 +48,10 @@ fun AlbumRow(
             contentPadding = PaddingValues(horizontal = 16.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            items(
+            itemsIndexed(
                 items = albums,
-                key = { "$title-${it.album.slug}" },
-            ) { album ->
+                key = { i, album -> "${album.album.slug}-$i" },
+            ) { _, album ->
                 val streamingLink = StreamingServices
                     .from(album.album)
                     .getStreamingLinkFor(streamingPlatform)

--- a/feature/overview/src/main/java/dk/clausr/feature/overview/details/AlbumDetailsViewModel.kt
+++ b/feature/overview/src/main/java/dk/clausr/feature/overview/details/AlbumDetailsViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
+import java.time.Instant
 import javax.inject.Inject
 
 @HiltViewModel
@@ -32,7 +33,10 @@ class AlbumDetailsViewModel @Inject constructor(
         AlbumDetailsViewState(
             album = historicAlbum,
             streamingPlatform = streaming,
-            relatedAlbums = getRelatedAlbums(historicAlbum.album.artist),
+            relatedAlbums = getRelatedAlbums(
+                artist = historicAlbum.album.artist,
+                generatedAt = historicAlbum.metadata?.generatedAt
+            ),
         )
     }
         .stateIn(
@@ -41,9 +45,12 @@ class AlbumDetailsViewModel @Inject constructor(
             initialValue = AlbumDetailsViewState(),
         )
 
-    private suspend fun getRelatedAlbums(artist: String): ImmutableList<HistoricAlbum> {
+    private suspend fun getRelatedAlbums(
+        artist: String,
+        generatedAt: Instant?,
+    ): ImmutableList<HistoricAlbum> {
         return oagRepository.getSimilarAlbums(artist)
-            .filterNot { it.album.slug == albumSlug }
+            .filterNot { it.album.slug == albumSlug && it.metadata?.generatedAt == generatedAt }
             .toPersistentList()
     }
 


### PR DESCRIPTION
This is a quickfix to avoid having the app crash when mutiple ratings of the same album is found.
Doesn't render well in details..