### PR TITLE
Align the way we show Album covers around the app.

### DIFF
--- a/core/ui/src/main/java/dk/clausr/a1001albumsgenerator/ui/components/AlbumCover.kt
+++ b/core/ui/src/main/java/dk/clausr/a1001albumsgenerator/ui/components/AlbumCover.kt
@@ -1,0 +1,59 @@
+package dk.clausr.a1001albumsgenerator.ui.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import coil3.request.placeholder
+import dk.clausr.a1001albumsgenerator.ui.R
+import dk.clausr.a1001albumsgenerator.ui.preview.consistentRandomColor
+
+@Composable
+fun AlbumCover(
+    coverUrl: String?,
+    albumSlug: String?,
+    modifier: Modifier = Modifier,
+    placeholderResId: Int = R.drawable.album_cover_placeholder,
+    shape: Shape = RoundedCornerShape(4.dp),
+    contentScale: ContentScale = ContentScale.FillWidth,
+) {
+    val sharedModifier = modifier
+        .fillMaxWidth()
+//        .aspectRatio(1f)
+        .clip(shape = shape)
+
+    if (LocalInspectionMode.current) {
+        Image(
+            painter = painterResource(placeholderResId),
+            contentDescription = null,
+            modifier = sharedModifier
+                .background(consistentRandomColor(albumSlug.orEmpty())),
+        )
+    } else {
+        AsyncImage(
+            model = ImageRequest
+                .Builder(LocalContext.current)
+                .data(coverUrl)
+                .crossfade(true)
+                .placeholderMemoryCacheKey(albumSlug)
+                .memoryCacheKey(albumSlug)
+                .placeholder(placeholderResId)
+                .build(),
+            contentDescription = null,
+            modifier = sharedModifier,
+            contentScale = contentScale,
+        )
+    }
+}

--- a/core/ui/src/main/java/dk/clausr/a1001albumsgenerator/ui/components/AlbumCover.kt
+++ b/core/ui/src/main/java/dk/clausr/a1001albumsgenerator/ui/components/AlbumCover.kt
@@ -2,6 +2,7 @@ package dk.clausr.a1001albumsgenerator.ui.components
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
@@ -12,6 +13,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
@@ -31,7 +33,7 @@ fun AlbumCover(
 ) {
     val sharedModifier = modifier
         .fillMaxWidth()
-//        .aspectRatio(1f)
+        .aspectRatio(1f)
         .clip(shape = shape)
 
     if (LocalInspectionMode.current) {
@@ -56,4 +58,13 @@ fun AlbumCover(
             contentScale = contentScale,
         )
     }
+}
+
+@Preview
+@Composable
+fun AlbumCoverPreview() {
+    AlbumCover(
+        coverUrl = null,
+        albumSlug = "null",
+    )
 }

--- a/core/ui/src/main/java/dk/clausr/a1001albumsgenerator/ui/components/AlbumThumb.kt
+++ b/core/ui/src/main/java/dk/clausr/a1001albumsgenerator/ui/components/AlbumThumb.kt
@@ -1,11 +1,8 @@
 package dk.clausr.a1001albumsgenerator.ui.components
 
 import androidx.compose.animation.SharedTransitionScope
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -22,22 +19,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalInspectionMode
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import coil3.compose.AsyncImage
-import coil3.request.ImageRequest
-import coil3.request.crossfade
 import dk.clausr.a1001albumsgenerator.ui.preview.PreviewSharedTransitionLayout
 import dk.clausr.a1001albumsgenerator.ui.theme.OagTheme
 import dk.clausr.core.model.HistoricAlbum
-import kotlin.random.Random
-import dk.clausr.a1001albumsgenerator.ui.R as uiR
 
 @Composable
 fun AlbumThumb(
@@ -72,38 +60,14 @@ fun AlbumThumb(
                     modifier = Modifier.fillMaxWidth(),
                     contentAlignment = Alignment.BottomEnd,
                 ) {
-                    if (LocalInspectionMode.current) {
-                        fun randomColor() = Color(Random.nextInt(0xFF000000.toInt(), 0xFFFFFFFF.toInt()))
-                        Image(
-                            painter = painterResource(uiR.drawable.album_cover_placeholder),
-                            contentDescription = null,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .background(randomColor())
-                                .aspectRatio(1f)
-                                .clip(shape = RoundedCornerShape(4.dp)),
+                    AlbumCover(
+                        coverUrl = coverUrl,
+                        albumSlug = albumSlug,
+                        modifier = Modifier.sharedElement(
+                            state = rememberSharedContentState(key = "$listName-cover-$albumSlug"),
+                            animatedVisibilityScope = animatedContentScope,
                         )
-                    } else {
-                        AsyncImage(
-                            model = ImageRequest
-                                .Builder(LocalContext.current)
-                                .data(coverUrl)
-                                .crossfade(true)
-                                .placeholderMemoryCacheKey(albumSlug)
-                                .memoryCacheKey(albumSlug)
-                                .build(),
-                            contentDescription = null,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .aspectRatio(1f)
-                                .sharedElement(
-                                    state = rememberSharedContentState(key = "$listName-cover-$albumSlug"),
-                                    animatedVisibilityScope = animatedContentScope,
-                                )
-                                .clip(shape = RoundedCornerShape(4.dp)),
-                            contentScale = ContentScale.FillWidth,
-                        )
-                    }
+                    )
 
                     onClickPlay?.let { onClickPlay ->
                         FilledTonalIconButton(

--- a/core/ui/src/main/java/dk/clausr/a1001albumsgenerator/ui/components/covergrid/CoverGrid.kt
+++ b/core/ui/src/main/java/dk/clausr/a1001albumsgenerator/ui/components/covergrid/CoverGrid.kt
@@ -69,7 +69,7 @@ fun CoverGrid(
 private fun CoverGridPreview() {
     OagTheme {
         Column(Modifier.fillMaxSize()) {
-            CoverGrid(modifier = Modifier.fillMaxHeight(0.5f))
+            CoverGrid(modifier = Modifier.fillMaxHeight())
         }
     }
 }

--- a/core/ui/src/main/java/dk/clausr/a1001albumsgenerator/ui/preview/RandomColor.kt
+++ b/core/ui/src/main/java/dk/clausr/a1001albumsgenerator/ui/preview/RandomColor.kt
@@ -1,0 +1,12 @@
+package dk.clausr.a1001albumsgenerator.ui.preview
+
+import androidx.compose.ui.graphics.Color
+
+internal fun consistentRandomColor(key: String): Color {
+    val hash = key.hashCode() // Generate a hash from the key
+    val red = (hash shr 16 and 0xFF).toFloat() / 255
+    val green = (hash shr 8 and 0xFF).toFloat() / 255
+    val blue = (hash and 0xFF).toFloat() / 255
+
+    return Color(red = red, green = green, blue = blue, alpha = 1f) // Fully opaque color
+}

--- a/feature/overview/src/main/java/dk/clausr/feature/overview/BigCurrentAlbum.kt
+++ b/feature/overview/src/main/java/dk/clausr/feature/overview/BigCurrentAlbum.kt
@@ -1,6 +1,5 @@
 package dk.clausr.feature.overview
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -10,7 +9,6 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Star
@@ -25,18 +23,14 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import coil3.compose.AsyncImage
 import dk.clausr.a1001albumsgenerator.analytics.LocalAnalyticsHelper
+import dk.clausr.a1001albumsgenerator.ui.components.AlbumCover
 import dk.clausr.a1001albumsgenerator.ui.extensions.logClickEvent
 import dk.clausr.a1001albumsgenerator.ui.extensions.logRatingGiven
 import dk.clausr.a1001albumsgenerator.ui.helper.displayName
@@ -47,7 +41,7 @@ import dk.clausr.core.data_widget.SerializedWidgetState.Companion.projectUrl
 import dk.clausr.core.model.Album
 import dk.clausr.core.model.StreamingPlatform
 import dk.clausr.core.model.StreamingService
-import kotlin.random.Random
+import dk.clausr.feature.overview.preview.albumPreviewData
 import dk.clausr.a1001albumsgenerator.ui.R as uiR
 
 // TODO State and album should be together...
@@ -119,26 +113,10 @@ fun BigCurrentAlbum(
             modifier = Modifier.aspectRatio(1f),
             contentAlignment = Alignment.Center,
         ) {
-            // TODO Maybe create a common AsyncImage that works in preview.
-            if (LocalInspectionMode.current) {
-                fun randomColor() = Color(Random.nextInt(0xFF000000.toInt(), 0xFFFFFFFF.toInt()))
-                Image(
-                    painter = painterResource(dk.clausr.a1001albumsgenerator.ui.R.drawable.album_cover_placeholder),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(randomColor())
-                        .aspectRatio(1f)
-                        .clip(shape = RoundedCornerShape(4.dp)),
-                )
-            } else {
-                AsyncImage(
-                    modifier = Modifier.fillMaxWidth(),
-                    contentScale = ContentScale.FillWidth,
-                    model = album.imageUrl,
-                    contentDescription = "Cover",
-                )
-            }
+            AlbumCover(
+                coverUrl = album.imageUrl,
+                albumSlug = album.slug,
+            )
 
             if (newAlbumAvailable) {
                 Column(
@@ -256,7 +234,7 @@ fun BigCurrentAlbum(
 
 @Preview
 @Composable
-private fun CurrentAlbumPreview() {
+private fun NewAlbumAvailablePreview() {
     OagTheme {
         BigCurrentAlbum(
             newAlbumAvailable = true,
@@ -264,26 +242,23 @@ private fun CurrentAlbumPreview() {
             openProject = {},
             openLink = {},
             onRating = {},
-            album = Album(
-                id = "id",
-                artist = "Black Sabbath",
-                artistOrigin = "UK",
-                name = "Paranoid",
-                slug = "paranoid",
-                releaseDate = "1970",
-                globalReviewsUrl = "https://1001albumsgenerator.com/albums/7DBES3oV6jjAmWob7kJg6P/paranoid",
-                wikipediaUrl = "https://en.wikipedia.org/wiki/Paranoid_(album)",
-                spotifyId = "7DBES3oV6jjAmWob7kJg6P",
-                appleMusicId = "785232473",
-                tidalId = 34450059,
-                amazonMusicId = "B073JYN27B",
-                youtubeMusicId = "OLAK5uy_l-gXxtv23EojUteRu5Zq1rKW3InI_bwsU",
-                genres = emptyList(),
-                subGenres = emptyList(),
-                imageUrl = "https://i.scdn.co/image/ab2eae28bb2a55667ee727711aeccc7f37498414",
-                qobuzId = null,
-                deezerId = null,
-            ),
+            album = albumPreviewData("black-sabbath"),
         )
     }
 }
+
+@Preview
+@Composable
+private fun CurrentAlbumPreview() {
+    OagTheme {
+        BigCurrentAlbum(
+            newAlbumAvailable = false,
+            streamingService = StreamingService("id", StreamingPlatform.Spotify),
+            openProject = {},
+            openLink = {},
+            onRating = {},
+            album = albumPreviewData("black-sabbath"),
+        )
+    }
+}
+

--- a/feature/overview/src/main/java/dk/clausr/feature/overview/details/AlbumDetailsScreen.kt
+++ b/feature/overview/src/main/java/dk/clausr/feature/overview/details/AlbumDetailsScreen.kt
@@ -4,19 +4,15 @@ import android.content.Context
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.animation.SharedTransitionScope
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlayArrow
@@ -30,11 +26,8 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontStyle
@@ -43,10 +36,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil3.compose.AsyncImage
-import coil3.request.ImageRequest
-import coil3.request.crossfade
 import dk.clausr.a1001albumsgenerator.analytics.AnalyticsEvent
+import dk.clausr.a1001albumsgenerator.ui.components.AlbumCover
 import dk.clausr.a1001albumsgenerator.ui.components.LocalNavAnimatedVisibilityScope
 import dk.clausr.a1001albumsgenerator.ui.components.LocalSharedTransitionScope
 import dk.clausr.a1001albumsgenerator.ui.extensions.TrackScreenViewEvent
@@ -60,7 +51,6 @@ import dk.clausr.feature.overview.R
 import dk.clausr.feature.overview.preview.historicAlbumPreviewData
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
-import kotlin.random.Random
 
 @Composable
 fun AlbumDetailsRoute(
@@ -116,36 +106,15 @@ fun AlbumDetailsScreen(
                     .navigationBarsPadding()
                     .padding(paddingValues),
             ) {
-                // TODO Maybe create a common AsyncImage that works in preview.
-                if (LocalInspectionMode.current) {
-                    fun randomColor() = Color(Random.nextInt(0xFF000000.toInt(), 0xFFFFFFFF.toInt()))
-                    Image(
-                        painter = painterResource(dk.clausr.a1001albumsgenerator.ui.R.drawable.album_cover_placeholder),
-                        contentDescription = null,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .background(randomColor())
-                            .aspectRatio(1f)
-                            .clip(shape = RoundedCornerShape(4.dp)),
-                    )
-                } else {
-                    AsyncImage(
-                        model = ImageRequest.Builder(LocalContext.current)
-                            .data(historicAlbum?.album?.imageUrl)
-                            .crossfade(true)
-                            .placeholderMemoryCacheKey(historicAlbum?.album?.slug)
-                            .memoryCacheKey(historicAlbum?.album?.slug)
-                            .build(),
-                        contentDescription = "Album cover",
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .sharedElement(
-                                state = rememberSharedContentState(key = "$listName-cover-${historicAlbum?.album?.slug}"),
-                                animatedVisibilityScope = animatedContentScope,
-                            ),
-                        contentScale = ContentScale.FillWidth,
-                    )
-                }
+                AlbumCover(
+                    coverUrl = historicAlbum?.album?.imageUrl,
+                    albumSlug = historicAlbum?.album?.slug,
+                    modifier = Modifier
+                        .sharedElement(
+                            state = rememberSharedContentState(key = "$listName-cover-${historicAlbum?.album?.slug}"),
+                            animatedVisibilityScope = animatedContentScope,
+                        )
+                )
 
                 Text(
                     modifier = Modifier


### PR DESCRIPTION
Enables previews to be consistant wrt background color.
Enables placeholders for all covers if they're not cached yet.